### PR TITLE
Remove automatically setting MaxPermSize #218

### DIFF
--- a/Runjettyrun/plugin/src/runjettyrun/JettyLaunchConfigurationType.java
+++ b/Runjettyrun/plugin/src/runjettyrun/JettyLaunchConfigurationType.java
@@ -295,16 +295,6 @@ public class JettyLaunchConfigurationType extends
 			throws CoreException {
 		List<String> runtimeVmArgs = getJettyArgs(configuration,debugMode);
 
-		boolean maxperm = false;
-		for (String str : oringinalVMArguments) {
-			if (str != null && str.indexOf("-XX:MaxPermSize") != -1)
-				maxperm = true;
-		}
-
-		if (!maxperm) {
-			runtimeVmArgs.add("-XX:MaxPermSize=128m");
-		}
-
 		// Here the classpath is really for web app.
 		runtimeVmArgs.add("-Drjrclasspath=" +
 				getWebappClasspath(configuration));


### PR DESCRIPTION
MaxPermSize is removed in newer versions of Java and running the plugin will fail with the automatically set option because it is not recognized anymore by the JVM. 